### PR TITLE
feat: keep trailing slash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# 0.2.0 (July 7, 2023)
+
+### Breaking
+
+- keep trailing slash in paths, they were previously normalized away ([#6])

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tower-sanitize-path"
 description = "Tower middleware to sanitize request paths"
-version = "0.1.2"
+version = "0.2.0"
 license = "Apache-2.0"
 repository = "https://github.com/shuttle-hq/tower-sanitize-path"
 documentation = "https://docs.rs/tower-sanitize-path"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,9 +71,10 @@ fn sanitize_path(uri: &mut Uri) {
     let path = uri.path();
     let path_decoded = decode(path);
 
-    // Check if the path contains a trailing slash.
+    // Check if the path contains a trailing slash and that it is not the only
+    // character.
     let trailing_slash = if let Some(char) = path_decoded.chars().last() {
-        char == '/'
+        char == '/' && path_decoded.len() > 1
     } else {
         false
     };
@@ -208,6 +209,14 @@ mod tests {
     #[test]
     fn keep_trailing_slash() {
         let mut uri = "/path/".parse().unwrap();
+        sanitize_path(&mut uri);
+
+        assert_eq!(uri, "/path/");
+    }
+
+    #[test]
+    fn keep_only_one_trailing_slash() {
+        let mut uri = "/path//".parse().unwrap();
         sanitize_path(&mut uri);
 
         assert_eq!(uri, "/path/");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,11 +73,12 @@ fn sanitize_path(uri: &mut Uri) {
 
     // Check if the path contains a trailing slash and that it is not the only
     // character.
-    let trailing_slash = if let Some(char) = path_decoded.chars().last() {
-        char == '/' && path_decoded.len() > 1
-    } else {
-        false
-    };
+    let trailing_slash = path_decoded.len() > 1
+        && path_decoded
+            .chars()
+            .last()
+            .filter(|char| *char == '/')
+            .is_some();
 
     let path_buf = PathBuf::from_str(&path_decoded).expect("infallible");
 


### PR DESCRIPTION
This makes it so this layer does not strip away trailing slashes from paths, which was unexpected behavior. It was happening because `Path::components` normalizes away trailing slashes. 

I added a new test for the case of a trailing slash in the path.